### PR TITLE
attempt at having users#preferences to redirect to modal if no email add...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development, :test do
 end
 
 group :production do
-  gem 'pg'
+  # gem 'pg'
   gem 'rails_12factor'
 end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,13 @@ before_action :set_user, only: [:show, :update, :preferences]
   end
 
   def preferences
-    @user = User.find(params[:id])
+    if @user.email
+      @user = User.find(params[:id])
+    else
+      flash.now.notice = "You must register a valid email address!"
+      redirect_to user_path(@user)
+      # render partial:'/welcome/modal' #this doesn't work
+    end
   end
 
   def email_settings

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-before_action :set_user, only: [:show, :update, :preferences]
+before_action :set_user, only: [:show, :update, :preferences, :email_settings]
 
   def show
     @user = User.find(params[:id])
@@ -10,17 +10,24 @@ before_action :set_user, only: [:show, :update, :preferences]
       @user = User.find(params[:id])
     else
       flash.now.notice = "You must register a valid email address!"
+      raise
+      # render partial:'/welcome/modal' 
       redirect_to user_path(@user)
-      # render partial:'/welcome/modal' #this doesn't work
     end
   end
 
   def email_settings
-    @user = User.find(params[:id])
-    @user.email_preferences = set_email_preferences
-    @user.save
-    flash.now.notice = "Email preferences saved!"
-    render :show
+    if @user.email
+      # @user.update_email_settings
+      # this should be refactored into the model
+      @user.email_preferences = set_email_preferences
+      @user.save
+      flash.now.notice = "Email preferences saved!"
+      render :show
+    else
+      flash.notice = "You must register a valid email address!"
+      redirect_to user_path(@user)
+    end
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,6 @@ before_action :set_user, only: [:show, :update, :preferences, :update_email_sett
       @user = User.find(params[:id])
     else
       flash.now.notice = "You must register a valid email address!"
-      raise
       # render partial:'/welcome/modal' 
       redirect_to user_path(@user)
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,14 +1,12 @@
 class UsersController < ApplicationController
-before_action :set_user, only: [:show, :update, :preferences, :update_email_settings]
+  before_action :set_user, only: [:show, :update, :preferences, :update_email_settings]
 
   def show
     @user = User.find(params[:id])
   end
 
   def preferences
-    if @user.email
-      @user = User.find(params[:id])
-    else
+    unless @user.email
       flash.now.notice = "You must register a valid email address!"
       # render partial:'/welcome/modal' 
       redirect_to user_path(@user)
@@ -49,8 +47,8 @@ before_action :set_user, only: [:show, :update, :preferences, :update_email_sett
   def email_settings
     email_options = ["new_post", "event_update", "event_cancellation", "rsvp_confirmation"]
     preferences = {}
-    email_options.each do |preference|
-      preferences[preference] = "true" if params.has_key? preference
+    email_options.each do |option|
+      preferences[option] = "true" if params.has_key? option
     end
     preferences
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-before_action :set_user, only: [:show, :update, :preferences, :email_settings]
+before_action :set_user, only: [:show, :update, :preferences, :update_email_settings]
 
   def show
     @user = User.find(params[:id])
@@ -16,12 +16,9 @@ before_action :set_user, only: [:show, :update, :preferences, :email_settings]
     end
   end
 
-  def email_settings
+  def update_email_settings
     if @user.email
-      # @user.update_email_settings
-      # this should be refactored into the model
-      @user.email_preferences = set_email_preferences
-      @user.save
+      @user.update_email_preferences(email_settings)
       flash.now.notice = "Email preferences saved!"
       render :show
     else
@@ -50,12 +47,12 @@ before_action :set_user, only: [:show, :update, :preferences, :email_settings]
     @user = User.find(params[:id])
   end
 
-  def set_email_preferences
+  def email_settings
     email_options = ["new_post", "event_update", "event_cancellation", "rsvp_confirmation"]
-    email_preferences = {}
+    preferences = {}
     email_options.each do |preference|
-      email_preferences[preference] = "true" if params.has_key? preference
+      preferences[preference] = "true" if params.has_key? preference
     end
-    email_preferences
+    preferences
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,4 +36,11 @@ class User < ActiveRecord::Base
     nil
   end
 
+  def update_email_preferences(settings)
+    self.email_preferences = settings
+    self.save
+  rescue ActiveRecord::RecordInvalid
+    nil
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,10 +16,6 @@ class User < ActiveRecord::Base
 
   scope :set_recipients, -> (action){ where("email_preferences -> '#{action}' = 'true'") }
 
-  # def self.set_recipients(action)
-  #   User.where("email_preferences -> '#{action}' = 'true'") #hstore syntax
-  # end
-
   def self.find_or_create_from_omniauth(auth_hash)
     User.find_by(uid: auth_hash[:uid]) || User.create_from_omniauth(auth_hash)
   end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,3 @@
-<%# if params[:getting_started] %>
-  <%#= render 'welcome/modal'%>
-<%# end %>
-
 <div class='profile'>
   <div>
     <%= image_tag "#{@user.avatar_url}" %>
@@ -40,6 +36,5 @@
     <% end %>
   </ul>
 </div>
-
 
 <%=  link_to_modal "Update Email Settings", user_preferences_path, :class=>"button" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,7 @@
+<%# if params[:getting_started] %>
+  <%#= render 'welcome/modal'%>
+<%# end %>
+
 <div class='profile'>
   <div>
     <%= image_tag "#{@user.avatar_url}" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ mount Resque::Server.new, :at => "/resque"
   get "/users/:id"            => "users#show",            as: :user
   patch "/users/:id"          => "users#update",          as: :update_user
   get "/users/:id/settings"   => "users#preferences",     as: :user_preferences
-  post "/users/:id/email"     => "users#email_settings",  as: :email_settings
+  post "/users/:id/email"     => "users#update_email_settings",  as: :email_settings
 
 
   get "/signout"              => "sessions#destroy",      as: :sign_out

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -3,19 +3,6 @@ require 'spec_helper'
 describe EventsController do
   let!(:user){ create(:user) }
 
-  # describe "GET 'index'" do
-  #   it "returns http success" do
-  #     get 'index'
-  #     response.should be_success
-  #   end
-
-  #   it "shows all events" do
-  #     event = create(:event, host_id: user.id)
-  #     get 'index'
-  #     expect(assigns(:events)).to eq([event])
-  #   end
-  # end #end GET index
-
   describe "GET 'show'" do
     let(:event){ create(:event, host_id: user.id)}
     it "returns http success" do
@@ -27,7 +14,7 @@ describe EventsController do
       get 'show', id: event.id
       expect(assigns(:event)).to_not be_nil
     end
-  end #end GET show
+  end
 
   describe "GET 'new'" do
     context 'if logged in' do
@@ -52,7 +39,7 @@ describe EventsController do
         expect(flash[:notice]).to eq "You must be signed in."
       end
     end
-  end # end GET new
+  end 
 
   describe "POST 'create'" do
     context 'if logged in' do
@@ -71,10 +58,6 @@ describe EventsController do
           post :create, event: create(:event, host_id: user.id).attributes 
           expect(flash[:notice]).to eq "Event added!"
         end
-
-        # it 'increases user event count by 1' do
-        #   expect { post :create, event: build(:event).attributes }.to change(user.events, :count).by(1)
-        # end
 
         it 'changes event count by 1' do
           expect {post :create, event: build(:event, host_id: user.id).attributes }.to change(Event, :count).by(1)
@@ -122,7 +105,7 @@ describe EventsController do
         expect {post :create, event: build(:event).attributes }.to change(Event, :count).by(0)
       end
     end
-  end #end POST create
+  end 
 
   describe "GET 'edit'" do
     let(:event){create(:event, host_id: user.id) }
@@ -159,7 +142,6 @@ describe EventsController do
           expect(flash[:notice]).to eq "You are not authorized to edit this event!" 
         end
       end
-
     end
 
     context 'if not logged in' do
@@ -173,7 +155,7 @@ describe EventsController do
         expect(flash[:notice]).to eq "You must be signed in."
       end
     end
-  end # end GET edit
+  end 
 
   describe "PATCH 'update'" do
     let!(:event){create(:event, host_id: user.id) }
@@ -269,8 +251,7 @@ describe EventsController do
         expect(flash[:notice]).to eq "You must be signed in."
       end
     end
-
-  end #end patch update
+  end
 
   describe 'DELETE destroy' do
     let!(:event){ create(:event, host_id: user.id) }
@@ -482,7 +463,6 @@ describe EventsController do
           get :rsvp, id: event.id
           expect(flash[:notice]).to eq "You have already RSVP'd for this event!"
         end
-
       end
     end
   end
@@ -548,8 +528,7 @@ describe EventsController do
           expect(flash[:notice]).to eq "You can't flake from your own event!"
         end
       end
-    end
-    
+    end  
   end
     
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -36,6 +36,35 @@ describe UsersController do
   end
 
   describe "POST 'email settings" do
+    context 'if user has saved email address' do
+      let(:email_preferences){ {"new_post" => "true"} } #use stub here for set_email preference?
+      it 'should render show' do
+        post :email_settings, id: user.id
+        expect(response).to render_template :show
+      end
+
+      it 'should set flash message' do
+        post :email_settings, id: user.id
+        expect(flash[:notice]).to eq "Email preferences saved!"
+      end
+
+    end
+
+    context 'if user does not have email saved' do
+      before(:each) do
+        user.update(email: nil, email_preferences: nil)
+      end
+
+      it 'should redirect to user show' do
+        post :email_settings, id: user.id
+        expect(response).to redirect_to user_path(user)
+      end
+
+      it 'should set flash message' do
+        post :email_settings, id: user.id
+        expect(flash[:notice]).to eq "You must register a valid email address!"
+      end
+    end
   end
 
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -39,17 +39,17 @@ describe UsersController do
     context 'if user has saved email address' do
       let(:email_preferences){ {"new_post" => "true"} } #use stub here for set_email preference?
       it 'should render show' do
-        post :email_settings, id: user.id
+        post :update_email_settings, id: user.id
         expect(response).to render_template :show
       end
 
       it 'should set flash message' do
-        post :email_settings, id: user.id
+        post :update_email_settings, id: user.id
         expect(flash[:notice]).to eq "Email preferences saved!"
       end
 
       it 'should change user email preferences' do
-        post :email_settings, id: user.id
+        post :update_email_settings, id: user.id
         expect(user.email_preferences).to eq email_preferences
       end
 
@@ -61,12 +61,12 @@ describe UsersController do
       end
 
       it 'should redirect to user show' do
-        post :email_settings, id: user.id
+        post :update_email_settings, id: user.id
         expect(response).to redirect_to user_path(user)
       end
 
       it 'should set flash message' do
-        post :email_settings, id: user.id
+        post :update_email_settings, id: user.id
         expect(flash[:notice]).to eq "You must register a valid email address!"
       end
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -48,6 +48,11 @@ describe UsersController do
         expect(flash[:notice]).to eq "Email preferences saved!"
       end
 
+      it 'should change user email preferences' do
+        post :email_settings, id: user.id
+        expect(user.email_preferences).to eq email_preferences
+      end
+
     end
 
     context 'if user does not have email saved' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -15,6 +15,47 @@ describe UsersController do
     end
   end
 
+  describe "POST 'update'" do
+    let(:user){ create(:user, email: nil)}
+    let(:email_address){ "example@test.com"}
+
+    context 'if user updates' do
+
+      it 'should redirect to root' do
+        post :update, id: user.id, user: {email: email_address}
+        expect(response).to redirect_to root_path
+      end
+
+      it 'should upddate email address' do
+        post :update, id: user.id, user: {email: email_address}
+        expect(assigns(:user).email).to eq email_address
+      end
+
+       it 'sets flash message' do
+        post :update, id: user.id, user: {email: email_address}
+        expect(flash[:notice]).to eq "Email address saved!"
+      end
+    end
+
+    context 'if user fails to update' do
+      let!(:user){ create(:user, email: "example@test.com")}
+      let!(:user_with_same_email){ create(:user, email:nil) }
+
+      it 'sets flash message' do
+        post :update, id: user_with_same_email.id, user: {email: "example@test.com"}
+        expect(flash[:notice]).to eq "Email has already been taken"
+      end
+
+      it 'redirects to home and render partial' do
+        post :update, id: user_with_same_email.id, user: {email: "example@test.com"}
+        expect(response).to redirect_to root_path(getting_started: true)
+      end
+  
+    end
+
+
+  end
+
   describe "GET 'preferences'" do
     context 'if user has saved email address' do
       it "should render partial" do
@@ -27,11 +68,17 @@ describe UsersController do
       before(:each) do
         user.update(email: nil, email_preferences: nil)
       end
+
       xit 'should render email update partial' do
         get 'preferences', id: user.id
         p user
         expect(response).to render_template partial:'welcome/modal'
       end 
+
+      it 'sets flash message' do
+        get 'preferences', id: user.id
+        expect(flash[:notice]).to eq "You must register a valid email address!"
+      end
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -50,10 +50,7 @@ describe UsersController do
         post :update, id: user_with_same_email.id, user: {email: "example@test.com"}
         expect(response).to redirect_to root_path(getting_started: true)
       end
-  
     end
-
-
   end
 
   describe "GET 'preferences'" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -16,9 +16,22 @@ describe UsersController do
   end
 
   describe "GET 'preferences'" do
-    it "should render partial" do
-      get 'preferences', id: user.id
-      expect(response).to render_template :preferences 
+    context 'if user has saved email address' do
+      it "should render partial" do
+        get 'preferences', id: user.id
+        expect(response).to render_template :preferences 
+      end
+    end
+
+    context 'if user does not have email saved' do
+      before(:each) do
+        user.update(email: nil, email_preferences: nil)
+      end
+      xit 'should render email update partial' do
+        get 'preferences', id: user.id
+        p user
+        expect(response).to render_template partial:'welcome/modal'
+      end 
     end
   end
 


### PR DESCRIPTION
trying to test the preferences, and getting this error:

  1) UsersController GET 'preferences' if user does not have email saved should render email update partial
     Failure/Error: expect(response).to render_template partial:'welcome/modal'
       expecting partial <welcome/modal> but action rendered <["welcome/_modal", "_modal"]>.
       Expected {"welcome/_modal"=>1, "_modal"=>1} to include "welcome/modal".

Occasionally, I'm getting the entire user profile to render in the modal popup itself, which is strange.  Not entirely sure how to call the modal to update email address.
